### PR TITLE
make datalog evaluation fail on malformed rule

### DIFF
--- a/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
@@ -28,6 +28,7 @@ module Auth.Biscuit.Datalog.Executor
   , keepAuthorized'
   , defaultLimits
   , evaluateExpression
+  , extractVariables
 
   --
   , getFactsForRule
@@ -99,6 +100,9 @@ data ExecutionError
   -- ^ Evaluation did not converge in the alloted number of iterations
   | FactsInBlocks
   -- ^ Some blocks contained either rules or facts while it was forbidden
+  | InvalidRule
+  -- ^ Some rules were malformed: every variable present in their head must
+  -- appear in their body
   | ResultError ResultError
   -- ^ The evaluation ran to completion, but checks and policies were not
   -- fulfilled.

--- a/biscuit/test/Spec/SampleReader.hs
+++ b/biscuit/test/Spec/SampleReader.hs
@@ -217,14 +217,10 @@ compareExecErrors ee re =
         Timeout                            -> mustMatch $ key "RunLimit" . key "Timeout"
         TooManyFacts                       -> mustMatch $ key "RunLimit" . key "TooManyFacts"
         TooManyIterations                  -> mustMatch $ key "RunLimit" . key "TooManyIterations"
+        InvalidRule                        -> mustMatch $ key "FailedLogic" . key "InvalidBlockRule"
         FactsInBlocks                      -> assertFailure "FactsInBlocks can't happen here"
         ResultError (NoPoliciesMatched cs) -> mustMatch $ key "FailedLogic" . key "Unauthorized"
-        ResultError (FailedChecks cs)      ->
-          let isBogusRule = isJust $ re ^? key "FailedLogic" . key "InvalidBlockRule"
-              -- ^ invalid rules are silently ignored in haskell, so they materialize as
-              -- a failed check
-              isFailedCheck = isJust $ re ^? key "FailedLogic" . key "Unauthorized"
-           in assertBool errorMessage $ isBogusRule || isFailedCheck
+        ResultError (FailedChecks cs)      -> mustMatch $ key "FailedLogic" . key "Unauthorized"
         ResultError (DenyRuleMatched cs q) -> mustMatch $ key "FailedLogic" . key "Unauthorized"
 
 processFailedValidation :: (String -> IO ())

--- a/biscuit/test/Spec/Verification.hs
+++ b/biscuit/test/Spec/Verification.hs
@@ -74,7 +74,7 @@ unboundVarRule = testCase "Rule with unbound variable" $ do
   b1 <- mkBiscuit secret [block|check if operation("read");|]
   b2 <- addBlock [block|operation($unbound, "read") <- operation($any1, $any2);|] b1
   res <- authorizeBiscuit b2 [authorizer|operation("write");allow if true;|]
-  res @?= Left (Executor.ResultError $ Executor.FailedChecks $ pure [check|check if operation("read")|])
+  res @?= Left InvalidRule
 
 symbolRestrictions :: TestTree
 symbolRestrictions = testGroup "Restricted symbols in blocks"


### PR DESCRIPTION
Previously, malformed rules (rules where the head had unbound variables) were
silently ignored. Now it makes evaluation fail completely, which is a safer
default (and consistent with the rust implementation).

While a rule being silently ignored is okay with `checks` and `allow` policies,
it can be dangerous if it was intended to be used with a `deny` policy