### PR TITLE
biscuit-servant: improve flexibility

### DIFF
--- a/biscuit-servant/biscuit-servant.cabal
+++ b/biscuit-servant/biscuit-servant.cabal
@@ -57,6 +57,7 @@ test-suite biscuit-servant-test
     , bytestring
     , hspec
     , http-client
+    , mtl
     , servant
     , servant-server
     , servant-client

--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -75,6 +75,7 @@ module Auth.Biscuit
   , defaultLimits
   , ParseError (..)
   , ExecutionError (..)
+  , AuthorizedBiscuit (..)
   , AuthorizationSuccess (..)
   , MatchedQuery (..)
   , query
@@ -122,7 +123,8 @@ import           Auth.Biscuit.Datalog.ScopedExecutor (AuthorizationSuccess (..),
                                                       getSingleVariableValue,
                                                       getVariableValues,
                                                       queryAuthorizerFacts)
-import           Auth.Biscuit.Token                  (Biscuit,
+import           Auth.Biscuit.Token                  (AuthorizedBiscuit (..),
+                                                      Biscuit,
                                                       BiscuitEncoding (..),
                                                       BiscuitProof (..), Open,
                                                       OpenOrSealed,

--- a/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
@@ -83,7 +83,6 @@ data AuthorizationSuccess
 getBindings :: AuthorizationSuccess -> Set Bindings
 getBindings AuthorizationSuccess{matchedAllowQuery=MatchedQuery{bindings}} = bindings
 
-
 -- | Given a series of blocks and an authorizer, ensure that all
 -- the checks and policies match
 runAuthorizer :: BlockWithRevocationId

--- a/biscuit/test/Spec/Verification.hs
+++ b/biscuit/test/Spec/Verification.hs
@@ -46,7 +46,7 @@ singleBlock = testCase "Single block" $ do
   secret <- newSecret
   biscuit <- mkBiscuit secret [block|right("file1", "read");|]
   res <- authorizeBiscuit biscuit [authorizer|check if right("file1", "read");allow if true;|]
-  matchedAllowQuery <$> res @?= Right ifTrue
+  matchedAllowQuery . authorizationSuccess <$> res @?= Right ifTrue
 
 errorAccumulation :: TestTree
 errorAccumulation = testGroup "Error accumulation"


### PR DESCRIPTION
- `authHandlerWith` allows more customisation for token extraction
  and error handling
- `checkBiscuitWith` and `checkBiscuitMWith` allow more customisation for error handling
- `WithAuthorizer'` allows a custom reader type parameter, along with
  `withTransformation` which allows transforming an `AuthorizedBiscuit` into a custom type in a failable and effectful way.