### PR TITLE
Make tests work in read-only setups

### DIFF
--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -16,6 +16,8 @@ build-type:     Simple
 extra-source-files:
     README.md
     ChangeLog.md
+data-files: test/samples/v2/samples.json
+          , test/samples/v2/*.bc
 
 source-repository head
   type: git
@@ -79,6 +81,8 @@ test-suite biscuit-haskell-test
       Spec.ScopedExecutor
       Spec.Verification
       Paths_biscuit_haskell
+  autogen-modules:
+      Paths_biscuit_haskell
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -94,6 +98,8 @@ test-suite biscuit-haskell-test
     , cereal
     , containers
     , cryptonite
+    , directory
+    , filepath
     , lens
     , lens-aeson
     , mtl

--- a/biscuit/test/Spec.hs
+++ b/biscuit/test/Spec.hs
@@ -13,8 +13,8 @@ import qualified Spec.Verification   as Verification
 
 main :: IO ()
 main = do
-  SampleReader.generateCases
-  sampleReader <- SampleReader.getSpecs
+  sampleFiles <- SampleReader.generateCases
+  sampleReader <- SampleReader.getSpecs sampleFiles
   defaultMain $ testGroup "biscuit-haskell"
     [
       NewCrypto.specs


### PR DESCRIPTION
This aims at fixing the build of the biscuit-haskell package in nixpkgs (it's currently marked as broken because the tests are not run in the proper directory).

More details to come once I'm confident it's working.