### PR TITLE
Include test files to the cabal upload

### DIFF
--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -16,6 +16,8 @@ build-type:     Simple
 extra-source-files:
     README.md
     ChangeLog.md
+    test/samples/v2/samples.json
+    test/samples/v2/*.bc
 
 source-repository head
   type: git


### PR DESCRIPTION
By adding the test/samples/v2 directory to the `extra-source-files` directive, we have a more conclusive archive ready for upload to hackage:

```
$ cabal sdist biscuit-haskell
/path/to/biscuit-haskell-0.2.1.0.tar.gz

$ tar --list -f /path/to/biscuit-haskell-0.2.1.0.tar.gz | grep test/samples
biscuit-haskell-0.2.1.0/test/samples/v2/
biscuit-haskell-0.2.1.0/test/samples/v2/samples.json
biscuit-haskell-0.2.1.0/test/samples/v2/test10_authorizer_scope.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test11_authorizer_authority_caveats.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test12_authority_caveats.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test13_block_rules.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test14_regex_constraint.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test15_multi_queries_caveats.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test16_caveat_head_name.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test17_expressions.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test18_unbound_variables_in_rule.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test19_generating_ambient_from_variables.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test1_basic.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test20_sealed.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test21_parsing.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test22_default_symbols.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test23_execution_scope.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test2_different_root_key.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test3_invalid_signature_format.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test4_random_block.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test5_invalid_signature.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test6_reordered_blocks.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test7_scoped_rules.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test8_scoped_checks.bc
biscuit-haskell-0.2.1.0/test/samples/v2/test9_expired_token.bc
```

See #48.