### PR TITLE
biscuit: improve documentation for `getRevocationIds`

### DIFF
--- a/biscuit/src/Auth/Biscuit/Token.hs
+++ b/biscuit/src/Auth/Biscuit/Token.hs
@@ -492,7 +492,8 @@ parseBiscuitWith ParserConfig{..} bs =
 
 -- | Extract the list of revocation ids from a biscuit.
 -- To reject revoked biscuits, please use 'parseWith' instead. This function
--- should only be used for debugging purposes.
+-- should only be used for inspecting biscuits, not for deciding whether to
+-- reject them or not.
 getRevocationIds :: Biscuit proof check -> NonEmpty ByteString
 getRevocationIds Biscuit{authority, blocks} =
   let allBlocks = authority :| blocks


### PR DESCRIPTION
`getRevocationIds` can be used outside of debugging in a way that makes sense (eg when registering a token revocation ids upon baking). The important part is that it should not be used when validating a token.

fixes #54 