### PR TITLE
Fix operators precedence

### DIFF
--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -241,9 +241,8 @@ table = [ [ binary  "*" Mul
           , binary  ">"  GreaterThan
           , binary  "==" Equal
           ]
-        , [ binary  "&&" And
-          , binary  "||" Or
-          ]
+        , [ binary  "&&" And ]
+        , [ binary  "||" Or ]
         ]
 
 binary :: HasTopTermParsers 'InPredicate ctx

--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -161,7 +161,6 @@ predicateParser = do
 unary :: HasTopTermParsers 'InPredicate ctx => Parser (Expression' ctx)
 unary = choice
   [ unaryParens
-  , unaryNegate
   , unaryLength
   ]
 
@@ -180,7 +179,11 @@ unaryNegate = do
   skipSpace
   _ <- char '!'
   skipSpace
-  EUnary Negate <$> expressionParser
+  e <- choice
+         [ methodParser
+         , exprTerm
+         ]
+  pure $ EUnary Negate e
 
 unaryLength :: HasTopTermParsers 'InPredicate ctx => Parser (Expression' ctx)
 unaryLength = do
@@ -219,7 +222,7 @@ methodParser = do
   pure $ EBinary method e1 e2
 
 expressionParser :: HasTopTermParsers 'InPredicate ctx => Parser (Expression' ctx)
-expressionParser = Expr.makeExprParser (methodParser <|> exprTerm) table
+expressionParser = Expr.makeExprParser (unaryNegate <|> methodParser <|> exprTerm) table
 
 table :: HasTopTermParsers 'InPredicate ctx
       => [[Expr.Operator Parser (Expression' ctx)]]

--- a/biscuit/test/Spec/Parser.hs
+++ b/biscuit/test/Spec/Parser.hs
@@ -328,6 +328,24 @@ operatorPrecedences = testGroup "mixed-precedence operators"
                    (EValue $ Variable "4")
                  )
               )
+  , testCase "&& ||" $
+      parseExpression "$0 || $1 && $2" @?=
+        Right (EBinary Or
+                 (EValue $ Variable "0")
+                 (EBinary And
+                   (EValue $ Variable "1")
+                   (EValue $ Variable "2")
+                 )
+              )
+  , testCase "&&" $
+      parseExpression "$0 && $1 && $2" @?=
+        Right (EBinary And
+                 (EBinary And
+                   (EValue $ Variable "0")
+                   (EValue $ Variable "1")
+                 )
+                 (EValue $ Variable "2")
+              )
   , testCase "!false && true" $
       parseExpression "!false && true" @?=
         Right (EBinary And

--- a/biscuit/test/Spec/Parser.hs
+++ b/biscuit/test/Spec/Parser.hs
@@ -314,6 +314,43 @@ operatorPrecedences = testGroup "mixed-precedence operators"
                     (EValue $ LInteger 4)
                   )
               )
+  , testCase "! && || ==" $
+      parseExpression "$0 && $1 || !$3 == $4" @?=
+        Right (EBinary Or
+                 (EBinary And
+                   (EValue $ Variable "0")
+                   (EValue $ Variable "1")
+                 )
+                 (EBinary Equal
+                   (EUnary Negate
+                     (EValue $ Variable "3")
+                   )
+                   (EValue $ Variable "4")
+                 )
+              )
+  , testCase "!false && true" $
+      parseExpression "!false && true" @?=
+        Right (EBinary And
+                (EUnary Negate
+                  (EValue $ LBool False)
+                )
+                (EValue $ LBool True)
+              )
+  , testCase "!$2.length()" $
+      parseExpression "!$2.length()" @?=
+        Right (EUnary Negate
+                (EUnary Length
+                  (EValue $ Variable "2")
+                )
+              )
+  , testCase "!$0.starts_with($1)" $
+      parseExpression "!$0.starts_with($1)" @?=
+        Right (EUnary Negate
+                (EBinary Prefix
+                  (EValue $ Variable "0")
+                  (EValue $ Variable "1")
+                )
+              )
   ]
 
 ruleWithScopeParsing :: TestTree


### PR DESCRIPTION
negation (`!`)'s precedence was too weak, and `&&` and `||` had the same precedence.

Tests fail for now because the rust implementation has the same issue, so samples are buggy as well.