### PR TITLE
Allow parameter substitution for sets

### DIFF
--- a/biscuit-servant/test/ClientHelpers.hs
+++ b/biscuit-servant/test/ClientHelpers.hs
@@ -12,9 +12,9 @@ import           Network.HTTP.Client      (defaultManagerSettings, newManager)
 import qualified Network.Wai.Handler.Warp as Warp
 import           Servant
 import           Servant.Client
+import qualified Servant.Client.Core      as ClientCore
 import           Servant.Client.Core      (AuthClientData, AuthenticatedRequest,
                                            mkAuthenticatedRequest)
-import qualified Servant.Client.Core      as ClientCore
 
 protect :: Text -> AuthenticatedRequest (AuthProtect "biscuit")
 protect b = mkAuthenticatedRequest b (ClientCore.addHeader "Authorization" . ("Bearer " <>))

--- a/biscuit/Setup.hs
+++ b/biscuit/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -414,7 +414,7 @@ data CheckKind = One | All
 
 data Check' evalCtx ctx = Check
   { cQueries :: Query' evalCtx ctx
-  , cKind :: CheckKind
+  , cKind    :: CheckKind
   }
 deriving instance ( Eq (QueryItem' evalCtx ctx)
                   ) => Eq (Check' evalCtx ctx)

--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -88,7 +89,7 @@ module Auth.Biscuit.Datalog.AST
   , renderAuthorizer
   , renderFact
   , renderRule
-  , toSetTerm
+  , valueToSetTerm
   , toStack
   ) where
 
@@ -96,7 +97,7 @@ import           Control.Applicative        ((<|>))
 import           Control.Monad              ((<=<))
 import           Data.ByteString            (ByteString)
 import           Data.ByteString.Base16     as Hex
-import           Data.Foldable              (fold)
+import           Data.Foldable              (fold, toList)
 import           Data.Map.Strict            (Map)
 import qualified Data.Map.Strict            as Map
 import           Data.Set                   (Set)
@@ -238,7 +239,7 @@ instance  ( Lift (VariableType inSet pof)
 
 -- | This class describes how to turn a haskell value into a datalog value.
 -- | This is used when slicing a haskell variable in a datalog expression
-class ToTerm t where
+class ToTerm t inSet pof where
   -- | How to turn a value into a datalog item
   toTerm :: t -> Term' inSet pof 'Representation
 
@@ -246,54 +247,57 @@ class ToTerm t where
 class FromValue t where
   fromValue :: Value -> Maybe t
 
-instance ToTerm Int where
+instance ToTerm Int inSet pof where
   toTerm = LInteger
 
 instance FromValue Int where
   fromValue (LInteger v) = Just v
   fromValue _            = Nothing
 
-instance ToTerm Integer where
+instance ToTerm Integer inSet pof where
   toTerm = LInteger . fromIntegral
 
 instance FromValue Integer where
   fromValue (LInteger v) = Just (fromIntegral v)
   fromValue _            = Nothing
 
-instance ToTerm Text where
+instance ToTerm Text inSet pof where
   toTerm = LString
 
 instance FromValue Text where
   fromValue (LString t) = Just t
   fromValue _           = Nothing
 
-instance ToTerm Bool where
+instance ToTerm Bool inSet pof where
   toTerm = LBool
 
 instance FromValue Bool where
   fromValue (LBool b) = Just b
   fromValue _         = Nothing
 
-instance ToTerm ByteString where
+instance ToTerm ByteString inSet pof where
   toTerm = LBytes
 
 instance FromValue ByteString where
   fromValue (LBytes bs) = Just bs
   fromValue _           = Nothing
 
-instance ToTerm UTCTime where
+instance ToTerm UTCTime inSet pof where
   toTerm = LDate
 
 instance FromValue UTCTime where
   fromValue (LDate t) = Just t
   fromValue _         = Nothing
 
+instance (Foldable f, ToTerm a 'WithinSet 'InFact) => ToTerm (f a) 'NotWithinSet pof where
+  toTerm vs = TermSet . Set.fromList $ toTerm <$> toList vs
+
 instance FromValue Value where
   fromValue = Just
 
-toSetTerm :: Value
-          -> Maybe (Term' 'WithinSet 'InFact 'Representation)
-toSetTerm = \case
+valueToSetTerm :: Value
+               -> Maybe (Term' 'WithinSet 'InFact 'Representation)
+valueToSetTerm = \case
   LInteger i  -> Just $ LInteger i
   LString i   -> Just $ LString i
   LDate i     -> Just $ LDate i

--- a/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
@@ -436,7 +436,7 @@ evalBinary _ Or (LBool b) (LBool b') = pure $ LBool (b || b')
 evalBinary _ Or _ _ = Left "Only booleans support ||"
 -- set operations
 evalBinary _ Contains (TermSet t) (TermSet t') = pure $ LBool (Set.isSubsetOf t' t)
-evalBinary _ Contains (TermSet t) t' = case toSetTerm t' of
+evalBinary _ Contains (TermSet t) t' = case valueToSetTerm t' of
     Just t'' -> pure $ LBool (Set.member t'' t)
     Nothing  -> Left "Sets cannot contain nested sets nor variables"
 evalBinary _ Contains (LString t) (LString t') = pure $ LBool (t' `isInfixOf` t)

--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RecordWildCards#-}
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
@@ -10,6 +9,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TupleSections         #-}

--- a/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}

--- a/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
@@ -23,13 +23,13 @@ module Auth.Biscuit.Datalog.ScopedExecutor
   , FactGroup (..)
   ) where
 
-import Data.List (genericLength)
 import           Control.Monad                 (unless, when)
 import           Control.Monad.State           (StateT (..), evalStateT, get,
                                                 gets, lift, put)
 import           Data.Bifunctor                (first)
 import           Data.ByteString               (ByteString)
 import           Data.Foldable                 (fold, traverse_)
+import           Data.List                     (genericLength)
 import           Data.List.NonEmpty            (NonEmpty)
 import qualified Data.List.NonEmpty            as NE
 import           Data.Map                      (Map)

--- a/biscuit/src/Auth/Biscuit/Example.hs
+++ b/biscuit/src/Auth/Biscuit/Example.hs
@@ -5,24 +5,28 @@ module Auth.Biscuit.Example where
 import           Data.ByteString (ByteString)
 import           Data.Functor    (($>))
 import           Data.Maybe      (fromMaybe)
+import           Data.Text       (Text)
 import           Data.Time       (getCurrentTime)
 
 import           Auth.Biscuit
 
 privateKey' :: SecretKey
-privateKey' = fromMaybe (error "Error parsing private key") $ parseSecretKeyHex "todo"
+privateKey' = fromMaybe (error "Error parsing private key") $ parseSecretKeyHex "a2c4ead323536b925f3488ee83e0888b79c2761405ca7c0c9a018c7c1905eecc"
 
 publicKey' :: PublicKey
-publicKey' = fromMaybe (error "Error parsing public key") $ parsePublicKeyHex "todo"
+publicKey' = fromMaybe (error "Error parsing public key") $ parsePublicKeyHex "24afd8171d2c0107ec6d5656aa36f8409184c2567649e0a7f66e629cc3dbfd70"
 
 creation :: IO ByteString
 creation = do
+  let allowedOperations = ["read", "write"] :: [Text]
+      networkLocal = "192.168.0.1" :: Text
   let authority = [block|
-       // toto
-       resource("file1");
+       // this is a comment
+       right("file1", ${allowedOperations});
+       check if source_ip($source_ip), ["127.0.0.1", ${networkLocal}].contains($source_ip);
        |]
   biscuit <- mkBiscuit privateKey' authority
-  let block1 = [block|check if current_time($time), $time < 2021-05-08T00:00:00Z;|]
+  let block1 = [block|check if time($time), $time < 2025-05-08T00:00:00Z;|]
   newBiscuit <- addBlock block1 biscuit
   pure $ serializeB64 newBiscuit
 
@@ -30,7 +34,11 @@ verification :: ByteString -> IO Bool
 verification serialized = do
   now <- getCurrentTime
   biscuit <- either (fail . show) pure $ parseB64 publicKey' serialized
-  let authorizer' = [authorizer|current_time(${now});|]
+  let authorizer' = [authorizer|
+        time(${now});
+        source_ip("127.0.0.1");
+        allow if right("file1", $ops), $ops.contains("read");
+      |]
   result <- authorizeBiscuit biscuit authorizer'
   case result of
     Left e  -> print e $> False

--- a/biscuit/src/Auth/Biscuit/ProtoBufAdapter.hs
+++ b/biscuit/src/Auth/Biscuit/ProtoBufAdapter.hs
@@ -211,7 +211,7 @@ pbToCheck s PB.CheckV2{queries,kind} = do
   let cKind = case PB.getField kind of
         Just PB.All -> All
         Just PB.One -> One
-        Nothing -> One
+        Nothing     -> One
   pure Check{..}
 
 checkToPb :: ReverseSymbols -> Check -> PB.CheckV2

--- a/biscuit/test/Spec/Verification.hs
+++ b/biscuit/test/Spec/Verification.hs
@@ -11,7 +11,9 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Auth.Biscuit
-import           Auth.Biscuit.Datalog.AST      (Expression' (..), Query, Check, CheckKind (..), Check' (..),
+import           Auth.Biscuit.Datalog.AST      (Check, Check' (..),
+                                                CheckKind (..),
+                                                Expression' (..), Query,
                                                 QueryItem' (..), Term' (..))
 import           Auth.Biscuit.Datalog.Executor (MatchedQuery (..),
                                                 ResultError (..))


### PR DESCRIPTION
It was not possible to slice whole sets directly, on set elements. Now both elements and complete sets can be sliced in.

For convenience, sets can be sliced from any `Foldable`

```haskell
creation :: IO ByteString
creation = do
  let allowedOperations = ["read", "write"] :: [Text]
      networkLocal = "192.168.0.1" :: Text
  let authority = [block|
       // this is a comment
       right("file1", ${allowedOperations});
       check if source_ip($source_ip), ["127.0.0.1", ${networkLocal}].contains($source_ip);
       |]
```