### PR TITLE
biscuit: change the syntax for parameters from `${name}` to `{name}`

### DIFF
--- a/biscuit-servant/README.md
+++ b/biscuit-servant/README.md
@@ -44,7 +44,7 @@ userListHandler = withAuthorizer [authorizer|allow if right("userList")|]
 
 singleUserHandler :: Int -> AppM User
 singleUserHandler uid =
-  withAuthorizer [authorizer|allow if right("getUser", ${uid})|] $
+  withAuthorizer [authorizer|allow if right("getUser", {uid})|] $
   let user = find (\user -> userId user == uid) allUsers
    in maybe (throwError error404) (\user -> pure user) user
 ```

--- a/biscuit-servant/src/Auth/Biscuit/Servant.hs
+++ b/biscuit-servant/src/Auth/Biscuit/Servant.hs
@@ -134,11 +134,11 @@ import           Servant.Server.Experimental.Auth
 -- >                // the biscuit can decide if it's still valid
 -- >                // this show how to run an effectful check with
 -- >                // checkBiscuitM (getting the current time is an effect)
--- >                time(${now});
+-- >                time({now});
 -- >                // only allow biscuits granting access to the endpoint tagged "two"
 -- >                // AND for the provided int value. This shows how the checks can depend
 -- >                // on the http request contents.
--- >                allow if right("two", ${value});
+-- >                allow if right("two", {value});
 -- >              |]
 -- >   checkBiscuitM biscuit authorizer
 -- >     (pure 2)
@@ -171,7 +171,7 @@ import           Servant.Server.Experimental.Auth
 -- >
 -- > handler2 :: Int -> WithAuthorizer Handler Int
 -- > handler2 value = withAuthorizer
--- >   [authorizer|allow if right("two", ${value});|]
+-- >   [authorizer|allow if right("two", {value});|]
 -- >   (pure 2)
 -- >
 -- > handler3 :: WithAuthorizer Handler Int
@@ -183,7 +183,7 @@ import           Servant.Server.Experimental.Auth
 -- > server biscuit =
 -- >  let nowFact = do
 -- >        now <- liftIO getCurrentTime
--- >        pure [authorizer|time(${now});|]
+-- >        pure [authorizer|time({now});|]
 -- >      handleAuth :: WithAuthorizer Handler x -> Handler x
 -- >      handleAuth =
 -- >          handleBiscuit biscuit

--- a/biscuit-servant/test/AppWithAuthorizer.hs
+++ b/biscuit-servant/test/AppWithAuthorizer.hs
@@ -55,7 +55,7 @@ server :: Server API
 server b =
   let nowFact = do
         now <- liftIO getCurrentTime
-        pure [authorizer|time(${now});|]
+        pure [authorizer|time({now});|]
       handleAuth :: WithAuthorizer Handler x -> Handler x
       handleAuth =
           handleBiscuit b
@@ -69,7 +69,7 @@ handler1 :: H Int
 handler1 = withAuthorizer [authorizer|allow if right("one");|] $ pure 1
 
 handler2 :: Int -> H Int
-handler2 v = withAuthorizer [authorizer|allow if right("two", ${v});|] $ pure 2
+handler2 v = withAuthorizer [authorizer|allow if right("two", {v});|] $ pure 2
 
 handler3 :: H Int
 handler3 = withAuthorizer [authorizer|deny if true;|] $ pure 3

--- a/biscuit-servant/test/Spec.hs
+++ b/biscuit-servant/test/Spec.hs
@@ -68,11 +68,11 @@ mkE1Biscuit :: SecretKey -> IO (Biscuit Open Verified)
 mkE1Biscuit sk = mkBiscuit sk [block|right("one");|]
 
 mkE2Biscuit :: Int -> SecretKey -> IO (Biscuit Open Verified)
-mkE2Biscuit v sk = mkBiscuit sk [block|right("two", ${v});|]
+mkE2Biscuit v sk = mkBiscuit sk [block|right("two", {v});|]
 
 mkE4Biscuit :: Int -> SecretKey -> IO (Biscuit Open Verified)
-mkE4Biscuit v sk = mkBiscuit sk [block|user(${v});|]
+mkE4Biscuit v sk = mkBiscuit sk [block|user({v});|]
 
 addTtl :: UTCTime -> Biscuit Open Verified -> IO (Biscuit Open Verified)
 addTtl expiration =
-  addBlock [block|check if time($now), $now < ${expiration};|]
+  addBlock [block|check if time($now), $now < {expiration};|]

--- a/biscuit/README.md
+++ b/biscuit/README.md
@@ -47,7 +47,7 @@ verification serialized = do
   -- verifiers are defined inline, directly in datalog, through the `verifier`
   -- quasiquoter. datalog parsing and validation happens at compile time, but
   -- can still reference haskell variables.
-  let authorizer' = [authorizer|time(${now});
+  let authorizer' = [authorizer|time({now});
                                 allow if true;
                                |]
   -- `authorizeBiscuit` only works on valid biscuits, and runs the datalog verifications

--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -220,8 +220,8 @@ import qualified Data.Text                           as Text
 -- >       now <- getCurrentTime
 -- >       let verif = [authorizer|
 -- >                // the datalog snippets can reference haskell variables
--- >                // with the ${variableName} syntax
--- >                time(${now});
+-- >                // with the {variableName} syntax
+-- >                time({now});
 -- >
 -- >                // policies are tried in order. The first matching policy
 -- >                // will decide if the token is valid or not. If no policies

--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -208,7 +208,7 @@ data Term' (inSet :: IsWithinSet) (pof :: PredicateOrFact) (ctx :: DatalogContex
   | LBool Bool
   -- ^ A bool literal (eg. @true@)
   | Antiquote (SliceType ctx)
-  -- ^ A slice (eg. @${name}@)
+  -- ^ A slice (eg. @{name}@)
   | TermSet (SetType inSet ctx)
   -- ^ A set (eg. @[true, false]@)
 
@@ -765,9 +765,9 @@ renderExpression =
 -- to build composite blocks (eg if you need to generate a list of facts):
 --
 -- > -- build a block from multiple variables v1, v2, v3
--- > [block| value(${v1}); |] <>
--- > [block| value(${v2}); |] <>
--- > [block| value(${v3}); |]
+-- > [block| value({v1}); |] <>
+-- > [block| value({v2}); |] <>
+-- > [block| value({v3}); |]
 type Block = Block' 'Repr 'Representation
 type EvalBlock = Block' 'Eval 'Representation
 

--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -95,7 +95,7 @@ variableParser =
 
 haskellVariableParser :: Parser Text
 haskellVariableParser = l $ do
-  _ <- chunk "${"
+  _ <- chunk "{"
   leadingUS <- optional $ C.char '_'
   x <- if isJust leadingUS then C.letterChar else C.lowerChar
   xs <- takeWhileP (Just "_, ', or any alphanumeric char") (\c -> c == '_' || c == '\'' || isAlphaNum c)
@@ -121,7 +121,7 @@ termParser :: Parser (VariableType inSet pof)
            -> Parser (SetType inSet 'WithSlices)
            -> Parser (Term' inSet pof 'WithSlices)
 termParser parseVar parseSet = l $ choice
-  [ Antiquote . Slice <$> haskellVariableParser <?> "parameter (eg. ${paramName})"
+  [ Antiquote . Slice <$> haskellVariableParser <?> "parameter (eg. {paramName})"
   , Variable <$> parseVar <?> "datalog variable (eg. $variable)"
   , TermSet <$> parseSet <?> "set (eg. [1,2,3])"
   , LBytes <$> (chunk "hex:" *> hexParser) <?> "hex-encoded bytestring (eg. hex:00ff99)"
@@ -317,7 +317,7 @@ scopeParser = (<?> "scope annotation") $ do
   let elemParser = choice [ OnlyAuthority <$  chunk "authority"
                           , Previous      <$  chunk "previous"
                           , BlockId       <$>
-                             choice [ PkSlice <$> haskellVariableParser <?> "parameter (eg. ${paramName})"
+                             choice [ PkSlice <$> haskellVariableParser <?> "parameter (eg. {paramName})"
                                     , Pk <$> publicKeyParser <?> "public key (eg. ed25519/00ff99)"
                                     ]
                           ]
@@ -399,7 +399,7 @@ compileParser p build =
   either fail build . run p . T.pack
 
 -- | Quasiquoter for a rule expression. You can reference haskell variables
--- like this: @${variableName}@.
+-- like this: @{variableName}@.
 --
 -- You most likely want to directly use 'block' or 'authorizer' instead.
 rule :: QuasiQuoter
@@ -411,7 +411,7 @@ rule = QuasiQuoter
   }
 
 -- | Quasiquoter for a predicate expression. You can reference haskell variables
--- like this: @${variableName}@.
+-- like this: @{variableName}@.
 --
 -- You most likely want to directly use 'block' or 'authorizer' instead.
 predicate :: QuasiQuoter
@@ -423,7 +423,7 @@ predicate = QuasiQuoter
   }
 
 -- | Quasiquoter for a fact expression. You can reference haskell variables
--- like this: @${variableName}@.
+-- like this: @{variableName}@.
 --
 -- You most likely want to directly use 'block' or 'authorizer' instead.
 fact :: QuasiQuoter
@@ -435,7 +435,7 @@ fact = QuasiQuoter
   }
 
 -- | Quasiquoter for a check expression. You can reference haskell variables
--- like this: @${variableName}@.
+-- like this: @{variableName}@.
 --
 -- You most likely want to directly use 'block' or 'authorizer' instead.
 check :: QuasiQuoter
@@ -453,8 +453,8 @@ check = QuasiQuoter
 --
 -- > let fileName = "data.pdf"
 -- >  in [block|
--- >       // datalog can reference haskell variables with ${variableName}
--- >       resource(${fileName});
+-- >       // datalog can reference haskell variables with {variableName}
+-- >       resource({fileName});
 -- >       rule($variable) <- fact($value), other_fact($value);
 -- >       check if operation("read");
 -- >     |]
@@ -474,8 +474,8 @@ block = QuasiQuoter
 -- > do
 -- >   now <- getCurrentTime
 -- >   pure [authorizer|
--- >          // datalog can reference haskell variables with ${variableName}
--- >          current_time(${now});
+-- >          // datalog can reference haskell variables with {variableName}
+-- >          current_time({now});
 -- >          // authorizers can contain facts, rules and checks like blocks, but
 -- >          // also declare policies. While every check has to pass for a biscuit to
 -- >          // be valid, policies are tried in order. The first one to match decides

--- a/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/ScopedExecutor.hs
@@ -120,7 +120,7 @@ mkRevocationIdFacts authority blocks =
   let allIds :: [(Int, ByteString)]
       allIds = zip [0..] $ snd' <$> authority : blocks
       snd' (_,b,_) = b
-      mkFact (index, rid) = [fact|revocation_id(${index}, ${rid})|]
+      mkFact (index, rid) = [fact|revocation_id({index}, {rid})|]
    in Set.fromList $ mkFact <$> allIds
 
 data ComputeState

--- a/biscuit/src/Auth/Biscuit/Example.hs
+++ b/biscuit/src/Auth/Biscuit/Example.hs
@@ -22,8 +22,8 @@ creation = do
       networkLocal = "192.168.0.1" :: Text
   let authority = [block|
        // this is a comment
-       right("file1", ${allowedOperations});
-       check if source_ip($source_ip), ["127.0.0.1", ${networkLocal}].contains($source_ip);
+       right("file1", {allowedOperations});
+       check if source_ip($source_ip), ["127.0.0.1", {networkLocal}].contains($source_ip);
        |]
   biscuit <- mkBiscuit privateKey' authority
   let block1 = [block|check if time($time), $time < 2025-05-08T00:00:00Z;|]
@@ -35,7 +35,7 @@ verification serialized = do
   now <- getCurrentTime
   biscuit <- either (fail . show) pure $ parseB64 publicKey' serialized
   let authorizer' = [authorizer|
-        time(${now});
+        time({now});
         source_ip("127.0.0.1");
         allow if right("file1", $ops), $ops.contains("read");
       |]

--- a/biscuit/test/Spec/Parser.hs
+++ b/biscuit/test/Spec/Parser.hs
@@ -92,7 +92,7 @@ termsGroup = testGroup "Parse terms"
   , testCase "Date" $ parseTerm "2019-12-02T13:49:53Z" @?=
         Right (LDate $ read "2019-12-02 13:49:53 UTC")
   , testCase "Variable" $ parseTerm "$1" @?= Right (Variable "1")
-  , testCase "Antiquote" $ isLeft (parseTerm "${toto}") @? "Unsubstituted parameters triggers an error"
+  , testCase "Antiquote" $ isLeft (parseTerm "{toto}") @? "Unsubstituted parameters triggers an error"
   ]
 
 termsGroupQQ :: TestTree
@@ -104,12 +104,12 @@ termsGroupQQ = testGroup "Parse terms (in a QQ setting)"
         Right (LDate $ read "2019-12-02 13:49:53 UTC")
   , testCase "Variable" $ parseTermQQ "$1" @?= Right (Variable "1")
   , testGroup "Antiquote"
-     [ testCase "Variable name" $ parseTermQQ "${toto2_'}" @?= Right (Antiquote "toto2_'")
-     , testCase "Leading underscore" $ parseTermQQ "${_toto}" @?= Right (Antiquote "_toto")
-     , testCase "`_` is reserved" $ parseTermQQ "${_}" @?= Left "1:4:\n  |\n1 | ${_}\n  |    ^\nunexpected '}'\nexpecting letter\n"
-     , testCase "Variables are lower-cased" $ parseTermQQ "${Toto}" @?= Left "1:3:\n  |\n1 | ${Toto}\n  |   ^\nunexpected 'T'\nexpecting '_' or lowercase letter\n"
-     , testCase "_ is lower-case" $ parseTermQQ "${_Toto}" @?= Right (Antiquote "_Toto")
-     , testCase "unicode is allowed" $ parseTermQQ "${éllo}" @?= Right (Antiquote "éllo")
+     [ testCase "Variable name" $ parseTermQQ "{toto2_'}" @?= Right (Antiquote "toto2_'")
+     , testCase "Leading underscore" $ parseTermQQ "{_toto}" @?= Right (Antiquote "_toto")
+     , testCase "`_` is reserved" $ parseTermQQ "{_}" @?= Left "1:3:\n  |\n1 | {_}\n  |   ^\nunexpected '}'\nexpecting letter\n"
+     , testCase "Variables are lower-cased" $ parseTermQQ "{Toto}" @?= Left "1:2:\n  |\n1 | {Toto}\n  |  ^\nunexpected 'T'\nexpecting '_' or lowercase letter\n"
+     , testCase "_ is lower-case" $ parseTermQQ "{_Toto}" @?= Right (Antiquote "_Toto")
+     , testCase "unicode is allowed" $ parseTermQQ "{éllo}" @?= Right (Antiquote "éllo")
      ]
   ]
 

--- a/biscuit/test/Spec/Quasiquoter.hs
+++ b/biscuit/test/Spec/Quasiquoter.hs
@@ -42,7 +42,7 @@ antiquotedFact = testCase "Sliced fact" $
   let toto2' :: Text
       toto2' = "test"
       actual :: Fact
-      actual = [fact|right(${toto2'}, "read")|]
+      actual = [fact|right({toto2'}, "read")|]
    in actual @?=
     Predicate "right" [ LString "test"
                       , LString "read"
@@ -53,7 +53,7 @@ antiquotedRule = testCase "Sliced rule" $
   let toto :: Text
       toto = "test"
       actual :: Rule
-      actual = [rule|right($0, "read") <- resource( $0), operation("read", ${toto})|]
+      actual = [rule|right($0, "read") <- resource( $0), operation("read", {toto})|]
    in actual @?=
     Rule (Predicate "right" [Variable "0", LString "read"])
          [ Predicate "resource" [Variable "0"]

--- a/biscuit/test/Spec/Roundtrip.hs
+++ b/biscuit/test/Spec/Roundtrip.hs
@@ -166,22 +166,22 @@ thirdPartyBlocks r =
                    right("file1", "read");
                    right("file2", "read");
                    right("file1", "write");
-                   check if true trusting previous, ${pkOne};
+                   check if true trusting previous, {pkOne};
                |]) :|
                [ (Just sk1, [block|
                    query("block1");
-                   check if right("file2", "read") trusting ${pkTwo};
-                   check if right("file3", "read") trusting ${pkOne};
+                   check if right("file2", "read") trusting {pkTwo};
+                   check if right("file3", "read") trusting {pkOne};
                  |])
                , (Just sk2, [block|
                    query("block2");
-                   check if right("file2", "read") trusting ${pkTwo};
-                   check if right("file3", "read") trusting ${pkOne};
+                   check if right("file2", "read") trusting {pkTwo};
+                   check if right("file3", "read") trusting {pkOne};
                  |])
                , (Nothing, [block|
                    query("block3");
-                   check if right("file2", "read") trusting ${pkTwo};
-                   check if right("file3", "read") trusting ${pkThree};
+                   check if right("file2", "read") trusting {pkTwo};
+                   check if right("file3", "read") trusting {pkThree};
                  |])
                ]
    in testGroup "Third party blocks"

--- a/biscuit/test/Spec/ScopedExecutor.hs
+++ b/biscuit/test/Spec/ScopedExecutor.hs
@@ -134,8 +134,8 @@ thirdPartyBlocks = testCase "Third party blocks are correctly scoped" $ do
     let authority =
           [block|
             user(1234);
-            check if from3rd(1, true) trusting ${pkOne};
-            check if from3rd(2, true) trusting ${pkOne};
+            check if from3rd(1, true) trusting {pkOne};
+            check if from3rd(2, true) trusting {pkOne};
           |]
         block1 =
           [block|
@@ -148,7 +148,7 @@ thirdPartyBlocks = testCase "Third party blocks are correctly scoped" $ do
         verif =
           [authorizer|
             deny if from3rd(1, true);
-            allow if from3rd(1, true), from3rd(2, true) trusting ${pkOne};
+            allow if from3rd(1, true), from3rd(2, true) trusting {pkOne};
           |]
     let result = runAuthorizerNoTimeout defaultLimits
                    (authority, "", Nothing)


### PR DESCRIPTION
Out of consistency with the rust implementation, and also to avoid confusion with datalog variables.

Since until very recently, parameters were only supported in quasi quotes, the change should be caught as a compilation error.