### PR TITLE
biscuit-servant: relax types for error handlers

### DIFF
--- a/biscuit-servant/src/Auth/Biscuit/Servant.hs
+++ b/biscuit-servant/src/Auth/Biscuit/Servant.hs
@@ -536,7 +536,7 @@ checkBiscuit vb = do
 -- (on endpoints), 'withFallbackAuthorizer' and 'withPriorityAuthorizer' (on API sub-trees)
 -- and 'handleBiscuit' (on the whole API).
 checkBiscuitWith :: (MonadIO m, MonadError ServerError m)
-                 => (forall b. ExecutionError -> m b)
+                 => (ExecutionError -> m a)
                  -> Biscuit OpenOrSealed Verified
                  -> Authorizer
                  -> ReaderT (AuthorizedBiscuit OpenOrSealed) m a
@@ -578,7 +578,7 @@ checkBiscuitM vb mv h = do
 -- 'withFallbackAuthorizer' and 'withPriorityAuthorizer' (on API sub-trees) and 'handleBiscuit'
 -- (on the whole API).
 checkBiscuitMWith :: (MonadIO m, MonadError ServerError m)
-                  => (forall b. ExecutionError -> m b)
+                  => (ExecutionError -> m a)
                   -> Biscuit OpenOrSealed Verified
                   -> m Authorizer
                   -> ReaderT (AuthorizedBiscuit OpenOrSealed) m a
@@ -613,7 +613,7 @@ handleBiscuit b WithAuthorizer{authorizer_, handler_} =
 -- For simpler use cases, consider using 'checkBiscuitWith' instead, which works on regular
 -- servant handlers.
 handleBiscuitWith :: (MonadIO m, MonadError ServerError m)
-                  => (forall b. ExecutionError -> m b)
+                  => (ExecutionError -> m a)
                   -> Biscuit OpenOrSealed Verified
                   -> WithAuthorizer m a
                   -> m a


### PR DESCRIPTION
The error handlers forced a polymorphic return type. In practice, that meant only being able to return a `ServerError` through `throwError`.

For `handleBiscuitWith`, this just makes the signature simpler without actually changing what's possible: `handleBiscuitWith` is made to be used as a natural transformation, so the return type is still polymorphic.

For `checkBiscuitWith` and `checkBiscuitMWith`, which are made to be used in handlers directly, this will allow recovering from within the error handler.