### PR TITLE
ci: test build with newer ghcs

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        cabal: ["3.8.1.0"]
-        ghc: ["8.10.7", "9.0.2", "9.2.4"]
+        cabal: ["3.10.3.0"]
+        ghc: ["9.0.2", "9.2.4", "9.4.8", "9.6.5", "9.8.2"]
 
     steps:
     - uses: actions/checkout@v3

--- a/biscuit-servant/biscuit-servant.cabal
+++ b/biscuit-servant/biscuit-servant.cabal
@@ -36,9 +36,9 @@ library
     base                 >= 4.7 && <5,
     biscuit-haskell      >= 0.3 && < 0.4,
     bytestring           >= 0.10 && <0.12,
-    mtl                  ^>= 2.2,
+    mtl                  >= 2.2 && < 2.4,
     text                 >= 1.2 && <3,
-    servant-server       >= 0.18 && < 0.20,
+    servant-server       >= 0.18 && < 0.21,
     wai                  ^>= 3.2
   default-language: Haskell2010
 

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -13,7 +13,7 @@ copyright:      2021 Clément Delafargue
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-tested-with:    GHC ==8.10.7 || == 9.0.2 || ==9.2.4
+tested-with:    GHC ==9.0.2 || ==9.2.4 || ==9.6.5 || ==9.8.2
 extra-source-files:
     README.md
     ChangeLog.md

--- a/biscuit/biscuit-haskell.cabal
+++ b/biscuit/biscuit-haskell.cabal
@@ -49,24 +49,24 @@ library
   build-depends:
     base                 >= 4.7 && <5,
     async                ^>= 2.2,
-    base16               ^>= 0.3,
+    base16               >= 0.3 && <2.0,
     bytestring           >= 0.10 && <0.12,
     text                 >= 1.2 && <3,
     containers           ^>= 0.6,
     cryptonite           >= 0.27 && < 0.31,
     memory               >= 0.15 && < 0.19,
-    template-haskell     >= 2.16 && < 2.19,
+    template-haskell     >= 2.16 && < 2.22,
     base64               ^>= 0.4,
     cereal               ^>= 0.5,
-    mtl                  ^>= 2.2,
+    mtl                  >= 2.2 && < 2.4,
     parser-combinators   >= 1.2 && < 1.4,
     protobuf             ^>= 0.2,
     random               >= 1.0 && < 1.3,
     regex-tdfa           ^>= 1.3,
     th-lift-instances    ^>= 0.1,
     time                 ^>= 1.9,
-    validation-selective ^>= 0.1,
-    megaparsec           ^>= 9.2
+    validation-selective >= 0.1 && < 0.3,
+    megaparsec           >= 9.2 && < 9.7
   default-language: Haskell2010
 
 test-suite biscuit-haskell-test
@@ -89,7 +89,7 @@ test-suite biscuit-haskell-test
       async
     , aeson
     , base >=4.7 && <5
-    , base16 ^>=0.3
+    , base16 >=0.3 && <2.0
     , base64
     , biscuit-haskell
     , bytestring

--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -108,7 +108,6 @@ import           Control.Monad                       ((<=<))
 import           Control.Monad.Identity              (runIdentity)
 import           Data.Bifunctor                      (first)
 import           Data.ByteString                     (ByteString)
-import qualified Data.ByteString.Base16              as Hex
 import qualified Data.ByteString.Base64.URL          as B64
 import           Data.Foldable                       (toList)
 import           Data.Set                            (Set)
@@ -159,6 +158,7 @@ import           Auth.Biscuit.Token                  (AuthorizedBiscuit (..),
                                                       queryAuthorizerFacts,
                                                       queryRawBiscuitFacts,
                                                       seal, serializeBiscuit)
+import Auth.Biscuit.Utils                            (decodeHex, encodeHex')
 import qualified Data.Text                           as Text
 
 
@@ -249,7 +249,7 @@ blockContext c = mempty { bContext = Just c }
 
 -- | Decode a base16-encoded bytestring, reporting errors via `MonadFail`
 fromHex :: MonadFail m => ByteString -> m ByteString
-fromHex = either (fail . Text.unpack) pure . Hex.decodeBase16
+fromHex = either (fail . Text.unpack) pure . decodeHex
 
 -- $keypairs
 --
@@ -273,11 +273,11 @@ serializePublicKey = pkBytes
 
 -- | Serialize a 'SecretKey' to a hex-encoded bytestring
 serializeSecretKeyHex :: SecretKey -> ByteString
-serializeSecretKeyHex = Hex.encodeBase16' . skBytes
+serializeSecretKeyHex = encodeHex' . skBytes
 
 -- | Serialize a 'PublicKey' to a hex-encoded bytestring
 serializePublicKeyHex :: PublicKey -> ByteString
-serializePublicKeyHex = Hex.encodeBase16' . pkBytes
+serializePublicKeyHex = encodeHex' . pkBytes
 
 -- | Read a 'SecretKey' from raw bytes
 parseSecretKey :: ByteString -> Maybe SecretKey

--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -112,7 +112,6 @@ module Auth.Biscuit.Datalog.AST
 import           Control.Applicative        ((<|>))
 import           Control.Monad              ((<=<))
 import           Data.ByteString            (ByteString)
-import           Data.ByteString.Base16     as Hex
 import           Data.Foldable              (fold, toList)
 import           Data.Function              (on)
 import           Data.Int                   (Int64)
@@ -134,6 +133,7 @@ import           Numeric.Natural            (Natural)
 import           Validation                 (Validation (..), failure)
 
 import           Auth.Biscuit.Crypto        (PublicKey, pkBytes)
+import           Auth.Biscuit.Utils         (encodeHex)
 
 data IsWithinSet = NotWithinSet | WithinSet
 data DatalogContext
@@ -347,7 +347,7 @@ renderId' var set slice = \case
   LInteger int  -> pack $ show int
   LString str   -> pack $ show str
   LDate time    -> pack $ formatTime defaultTimeLocale "%FT%T%Q%Ez" time
-  LBytes bs     -> "hex:" <> Hex.encodeBase16 bs
+  LBytes bs     -> "hex:" <> encodeHex bs
   LBool True    -> "true"
   LBool False   -> "false"
   TermSet terms -> set terms
@@ -824,7 +824,7 @@ renderRuleScope =
   let renderScopeElem = \case
         OnlyAuthority -> "authority"
         Previous      -> "previous"
-        BlockId bs    -> "ed25519/" <> Hex.encodeBase16 (pkBytes bs)
+        BlockId bs    -> "ed25519/" <> encodeHex (pkBytes bs)
    in intercalate ", " . Set.toList . Set.map renderScopeElem
 
 renderBlock :: Block -> Text

--- a/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Parser.hs
@@ -15,11 +15,11 @@ module Auth.Biscuit.Datalog.Parser
 import           Auth.Biscuit.Crypto            (PublicKey,
                                                  readEd25519PublicKey)
 import           Auth.Biscuit.Datalog.AST
+import           Auth.Biscuit.Utils             (decodeHex)
 import           Control.Monad                  (join)
 import qualified Control.Monad.Combinators.Expr as Expr
 import           Data.Bifunctor
 import           Data.ByteString                (ByteString)
-import           Data.ByteString.Base16         as Hex
 import qualified Data.ByteString.Char8          as C8
 import           Data.Char
 import           Data.Either                    (partitionEithers)
@@ -149,14 +149,14 @@ intParser = do
 hexParser :: Parser ByteString
 hexParser = do
   (sp, hexStr) <- getSpan $ C8.pack <$> some C.hexDigitChar
-  case Hex.decodeBase16 hexStr of
+  case decodeHex hexStr of
     Left e   -> registerError (InvalidBs e) sp
     Right bs -> pure bs
 
 publicKeyParser :: Parser PublicKey
 publicKeyParser = do
   (sp, hexStr) <- getSpan $ C8.pack <$> (chunk "ed25519/" *> some C.hexDigitChar)
-  case Hex.decodeBase16 hexStr of
+  case decodeHex hexStr of
     Left e -> registerError (InvalidPublicKey e) sp
     Right bs -> case readEd25519PublicKey bs of
       Nothing -> registerError (InvalidPublicKey "Invalid ed25519 public key") sp

--- a/biscuit/src/Auth/Biscuit/Utils.hs
+++ b/biscuit/src/Auth/Biscuit/Utils.hs
@@ -1,13 +1,46 @@
-{-|
-  Module      : Auth.Biscuit.Utils
-  Copyright   : © Clément Delafargue, 2021
-  License     : MIT
-  Maintainer  : clement@delafargue.name
--}
+{-# LANGUAGE CPP #-}
+
+-- |
+--  Module      : Auth.Biscuit.Utils
+--  Copyright   : © Clément Delafargue, 2021
+--  License     : MIT
+--  Maintainer  : clement@delafargue.name
 module Auth.Biscuit.Utils
-  ( maybeToRight
-  , rightToMaybe
-  ) where
+  ( maybeToRight,
+    rightToMaybe,
+    encodeHex,
+    encodeHex',
+    decodeHex,
+  )
+where
+
+#if MIN_VERSION_base16(1,0,0)
+import qualified Data.Base16.Types as Hex
+#endif
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as Hex
+import Data.Text (Text)
+
+encodeHex :: ByteString -> Text
+#if MIN_VERSION_base16(1,0,0)
+encodeHex = Hex.extractBase16 . Hex.encodeBase16
+#else
+encodeHex = Hex.encodeBase16
+#endif
+
+encodeHex' :: ByteString -> ByteString
+#if MIN_VERSION_base16(1,0,0)
+encodeHex' = Hex.extractBase16 . Hex.encodeBase16'
+#else
+encodeHex' = Hex.encodeBase16'
+#endif
+
+decodeHex :: ByteString -> Either Text ByteString
+#if MIN_VERSION_base16(1,0,0)
+decodeHex = Hex.decodeBase16Untyped
+#else
+decodeHex = Hex.decodeBase16
+#endif
 
 -- | Exactly like `maybeToRight` from the `either` package,
 -- but without the dependency footprint

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,5 @@ packages:
   biscuit/
   biscuit-servant/
 
-index-state: 2022-11-22T14:25:56Z
 tests: True
 documentation: True


### PR DESCRIPTION
Support for GHC 9.4, 9.6 and 9.8.

This is mostly a matter of relaxing consraints. The only breaking change is in `base16` which introduced a marker type.

Interestingly enough, `Functor` is now a superclass of `Bifunctor`.